### PR TITLE
use secure url for contours json file

### DIFF
--- a/projects/radio/subject_viewer.coffee
+++ b/projects/radio/subject_viewer.coffee
@@ -20,7 +20,8 @@ class RadioSubjectViewer extends DefaultSubjectViewer
   constructor: ->
     super
 
-    contours = @subject.location.contours || @subject.location.contour
+    contours = (@subject.location.contours || @subject.location.contour)
+    contours = contours.replace /^http:/, 'https:'
     $.getJSON contours, @drawContours if d3?
 
     $(window).on("resize", => @drawContours())


### PR DESCRIPTION
fixes the issue of mixed content when trying to load the contours file for RGZ talk subject viewer.