### PR TITLE
Upgrade uglify and moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "es5-shimify": "~0.0.1",
     "hem": "git://github.com/chrissnyder/hem#b7595d3",
     "json2ify": "~0.0.1",
-    "moment": "~1.7.2",
+    "moment": "~2.11",
     "nib": "~0.8.2",
     "semver": "^5.1.0",
     "serveup": "~0.0.5",
     "spine": "1.0.8",
-    "uglify-js": "1.3.4",
+    "uglify-js": "~2.6",
     "zooniverse": "git://github.com/zooniverse/Zooniverse.git#core-no-jqueryify"
   },
   "scripts": {


### PR DESCRIPTION
Upgrades a couple of other packages that have known security vulnerabilities.

I think `moment` is used to calculate time ago on posts and comments. `uglify` is probably used to minify code during the build process.

The upgrade seemed to work without a hitch when I tried it out on Galaxy Zoo staging. Famous last words, I know…