### PR TITLE
Update button event handlers to fire with JQuery 3 upgrade

### DIFF
--- a/app/lib/follow_links.coffee
+++ b/app/lib/follow_links.coffee
@@ -1,7 +1,7 @@
 { project } = require 'lib/config'
 Api = require 'zooniverse/lib/api'
 
-$(window).on 'click', '.follow-link button', (event) ->
+$(document).on 'click', '.follow-link button', (event) ->
   event.preventDefault()
   link = $(event.target)
   action = link.attr 'name'

--- a/app/lib/moderation_links.coffee
+++ b/app/lib/moderation_links.coffee
@@ -1,7 +1,7 @@
 { project } = require 'lib/config'
 Api = require 'zooniverse/lib/api'
 
-$(window).on 'click', '.report-comment', (event) ->
+$(document).on 'click', '.report-comment', (event) ->
   if message = prompt('Please enter a brief message describing the problem with this comment:')
     el = $(event.target)
     { commentId, discussionId } = el.data()
@@ -9,38 +9,38 @@ $(window).on 'click', '.report-comment', (event) ->
     Api.post "/projects/#{ project }/talk/moderation/report_comment", body, =>
       el.replaceWith '<strong>Reported</strong>'
 
-$(window).on 'click', '.show-for-privileged-user.remove-comment', (event) ->
+$(document).on 'click', '.show-for-privileged-user.remove-comment', (event) ->
   if message = prompt('Please enter a brief message describing the problem with this comment:')
     el = $(event.target)
     { commentId, discussionId } = el.data()
     body = { comment_id: commentId, discussion_id: discussionId, comment: message }
-    
+
     Api.post "/projects/#{ project }/talk/moderation/delete_comment", body, =>
       el.closest('.comment,.post').remove()
 
-$(window).on 'click', '.remove-own-comment', (event) ->
+$(document).on 'click', '.remove-own-comment', (event) ->
   if confirm('Are you sure you want to remove this comment?\nThere is no undo.')
     el = $(event.target)
     { commentId, discussionId } = el.data()
-    
+
     Api.delete "/projects/#{ project }/talk/discussions/#{ discussionId }/comments/#{ commentId }", =>
       el.closest('.comment,.post').remove()
 
-$(window).on 'click', '.report-user', (event) ->
+$(document).on 'click', '.report-user', (event) ->
   if message = prompt('Please enter a brief message describing the problem with this user:')
     el = $(event.target)
     userName = el.data 'user-name'
     Api.post "/projects/#{ project }/talk/moderation/report_user", user_name: userName, message: message, (results) =>
       el.replaceWith '<strong>Reported</strong>'
 
-$(window).on 'click', '.user.page .ban-user', (event) ->
+$(document).on 'click', '.user.page .ban-user', (event) ->
   if message = prompt('Please enter a brief message describing the reason for banning this user:')
     el = $(event.target)
     userName = el.data('user-name')
     Api.post "/projects/#{ project }/talk/moderation/ban_user", user_name: userName, comment: message, (results) =>
       el.closest('.user-moderation').replaceWith require('views/moderation/user')(user: { name: userName, state: 'banned' })
 
-$(window).on 'click', '.user.page .redeem-user', (event) ->
+$(document).on 'click', '.user.page .redeem-user', (event) ->
   if message = prompt('Please enter a brief message describing the reason for redeeming this user:')
     el = $(event.target)
     userName = el.data('user-name')


### PR DESCRIPTION
bind the click event handlers to document instead of window. I am not sure why this is needed as the selector _should_ still find the element from the window -> document -> element to my limited knowledge. 

Be nice to figure out the exact different but in the meantime moving to document as the bind point works...